### PR TITLE
fix: semantic release protected branch issue

### DIFF
--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -14,9 +14,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-node@v4
         with:
           node-version: "18.17.0"
+
       - name: Action For Semantic Release
         uses: cycjimmy/semantic-release-action@v4.1.1
         with:


### PR DESCRIPTION
Added ```persist-credentials``` to semantic release workflow


[Github issue](https://github.com/semantic-release/semantic-release/discussions/2557)