### PR TITLE
fix: scoring mechanism use ground truth only, use L1 norm

### DIFF
--- a/commons/dataset/synthetic.py
+++ b/commons/dataset/synthetic.py
@@ -51,6 +51,13 @@ class SyntheticAPI:
         return
 
     @classmethod
+    async def close_session(cls):
+        if cls._session is not None:
+            await cls._session.close()
+            cls._session = None
+        logger.debug("Ensured SyntheticAPI session is closed.")
+
+    @classmethod
     async def get_qa(cls) -> SyntheticQA | None:
         await cls.init_session()
 

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -12,6 +12,7 @@ from scipy.stats import spearmanr
 from torch.nn import functional as F
 
 from dojo.protocol import (
+    CodeAnswer,
     CompletionResponses,
     CriteriaType,
     FeedbackRequest,
@@ -32,7 +33,6 @@ class GroundTruthScore(BaseModel):
         arbitrary_types_allowed = True
 
     score: torch.Tensor
-    raw_scores_by_miner: torch.Tensor
 
 
 class ConsensusScore(BaseModel):
@@ -48,7 +48,7 @@ class Score(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-    ground_truth: GroundTruthScore = Field(description="Raw score from ground truth")
+    ground_truth: torch.Tensor = Field(description="Raw score from ground truth")
     consensus: ConsensusScore = Field(description="Raw score from ground truth")
     weighted_consensus: torch.Tensor | None = Field(
         default=None, description="Weighted score from consensus"
@@ -72,6 +72,12 @@ def _get_ground_truth_by_criteria(criteria, model_with_score_sorted):
     elif isinstance(criteria, MultiScoreCriteria):
         gt = [score for _, score in model_with_score_sorted]
     return np.array(gt)
+
+
+def minmax_scale(tensor: torch.Tensor | np.ndarray) -> torch.Tensor:
+    min = tensor.min()
+    max = tensor.max()
+    return (tensor - min) / (max - min)
 
 
 class Scoring:
@@ -264,6 +270,86 @@ class Scoring:
         )
 
     @staticmethod
+    def ground_truth_score_V1(
+        criteria: CriteriaType,
+        ground_truth: dict[str, int],
+        miner_responses: List[FeedbackRequest],
+    ):
+        """
+        - Calculate score between all miner outputs and ground truth.
+        - Ensures that the resulting tensor is normalized to sum to 1.
+
+        Args:
+            criteria (CriteriaType): Criteria type
+            ground_truth (dict[str, int]): Ground truth, where key is completion id and value is rank.
+            miner_responses (List[FeedbackRequest]): Miner responses
+
+        Raises:
+            ValueError: If miner responses are empty or contain None values.
+
+        Returns:
+            torch.Tensor: 1D tensor of scores, representing score for each miner based on order in miner_responses.
+        """
+        cid_rank_tuples = [
+            (completion_id, rank) for completion_id, rank in ground_truth.items()
+        ]
+        logger.debug(f"scoring: cid rank tuples\n{cid_rank_tuples}")
+
+        cid_with_rank_sorted = sorted(
+            cid_rank_tuples, key=lambda x: x[1], reverse=False
+        )
+        logger.debug(f"scoring: cid with rank sorted\n{cid_with_rank_sorted}")
+        # sort miner outputs according to ground truth order
+        # we're using this because miners receive a shuffled order of the completions
+        cids_sorted = [cid for cid, _ in cid_with_rank_sorted]
+        miner_outputs = []
+        for response in miner_responses:
+            curr_miner_outputs = []
+            for completion in sorted(
+                response.completion_responses,
+                key=lambda r: cids_sorted.index(r.model),
+            ):
+                curr_miner_outputs.append(
+                    _get_miner_response_by_criteria(criteria, completion)
+                )
+            miner_outputs.append(curr_miner_outputs)
+        if miner_outputs == [] or None in miner_outputs:
+            raise ValueError("Miner outputs cannot be empty or contain None values")
+
+        miner_outputs = np.array(miner_outputs)
+        logger.debug(f"scoring: raw miner outputs\n{miner_outputs}")
+        # convert miner outputs to something ordinal
+        miner_outputs_normalised = np.array([minmax_scale(m) for m in miner_outputs])
+        logger.debug(
+            f"scoring: raw miner outputs with nans\n{miner_outputs_normalised}"
+        )
+
+        miner_outputs = miner_outputs_normalised
+        logger.debug(f"scoring: raw miner outputs with nans\n{miner_outputs}")
+
+        # use minmax scale to ensure ground truth is in the range [0, 1]
+        ground_truth_arr = minmax_scale(
+            np.array([rank for _, rank in cid_with_rank_sorted])
+        )
+        logger.debug(f"scoring: ground truth\n{ground_truth_arr}")
+
+        logger.info(f"scoring: Miner outputs\n{miner_outputs}")
+        logger.info(f"scoring: Ground truth\n{ground_truth_arr}")
+
+        l1_norm = np.linalg.norm(miner_outputs - ground_truth_arr, axis=1)
+        logger.debug(f"scoring: l1 norm\n{l1_norm}")
+
+        # case where a miner provides the same score for all completions
+        # convert any nans to zero
+        l1_norm = np.where(np.isnan(l1_norm), 0, l1_norm)
+
+        logger.debug(f"scoring: l1 norm no nans\n{l1_norm}")
+        # normalize to ensure sum is 1
+        l1_norm = l1_norm / np.sum(l1_norm)
+        logger.debug(f"scoring: l1 norm normalized (sum=1)\n{l1_norm}")
+        return torch.from_numpy(l1_norm)
+
+    @staticmethod
     def cmp_ground_truth(
         criteria: CriteriaType,
         request: FeedbackRequest,
@@ -316,10 +402,7 @@ class Scoring:
         gt_reward = F.softmax(diff_gt, dim=0)
         logger.debug(f"{gt_reward=}")
 
-        return GroundTruthScore(
-            score=torch.tensor(gt_reward),
-            raw_scores_by_miner=diff_gt,
-        )
+        return torch.tensor(gt_reward)
 
     @staticmethod
     def spm_ground_truth(
@@ -362,10 +445,7 @@ class Scoring:
         )  # Handle NaN values
         gt_reward = F.softmax(torch.tensor(spearman_scores, dtype=torch.float32), dim=0)
 
-        return GroundTruthScore(
-            score=gt_reward,
-            raw_scores_by_miner=spearman_scores,
-        )
+        return gt_reward
 
     @staticmethod
     def calculate_score(
@@ -375,7 +455,7 @@ class Scoring:
     ) -> tuple[dict[CriteriaType, Score], Dict[str, float]]:
         """Combines both consensus score and difference with ground truths scoring to output a final score per miner"""
         criteria_to_miner_scores = defaultdict(Score)
-        hotkey_to_final_score = defaultdict(float)
+        hotkey_to_final_score: dict[str, float] = defaultdict(float)
         for criteria in criteria_types:
             # valid responses
             valid_miner_responses = []
@@ -402,19 +482,23 @@ class Scoring:
                     criteria, request, valid_miner_responses
                 )
             else:
-                gt_score = Scoring.cmp_ground_truth(
+                gt_score = Scoring.ground_truth_score_V1(
                     criteria, request, valid_miner_responses
                 )
 
-            consensus_score = Scoring.consensus_score(
-                criteria, request, valid_miner_responses
-            )
+            # TODO @dev add heuristics once scoring is stable
+            # consensus_score = Scoring.consensus_score(
+            #     criteria, request, valid_miner_responses
+            # )
+
+            consensus_score = np.zeros(len(valid_miner_responses))
 
             for i, r in enumerate(valid_miner_responses):
-                consensus = 0.2 * consensus_score.score[i]
-                ground_truth = 0.8 * gt_score.score[i]
+                # consensus = 0.2 * consensus_score.score[i]
+                ground_truth = gt_score[i]
 
-                hotkey_to_final_score[r.axon.hotkey] = (consensus + ground_truth) / len(
+                # NOTE: just use ground truth for now
+                hotkey_to_final_score[r.axon.hotkey] = ground_truth / len(
                     criteria_types
                 )
 
@@ -468,3 +552,226 @@ def _map_ground_truth_rank_to_score(
         completion_id_score_tuples.append((completion_id, float(score)))
 
     return completion_id_score_tuples
+
+
+def _test_ground_truth_score_v1():
+    gt = {
+        "a": 0,
+        "b": 1,
+        "c": 2,
+        "d": 3,
+    }
+
+    a = CompletionResponses(
+        model="a", completion=CodeAnswer(files=[]), completion_id="a"
+    )
+    b = CompletionResponses(
+        model="b", completion=CodeAnswer(files=[]), completion_id="b"
+    )
+    c = CompletionResponses(
+        model="c", completion=CodeAnswer(files=[]), completion_id="c"
+    )
+    d = CompletionResponses(
+        model="d", completion=CodeAnswer(files=[]), completion_id="d"
+    )
+
+    criteria = MultiScoreCriteria(options=["a", "b", "c", "d"], min=0, max=100)
+
+    miner_responses = [
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=56
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=78
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=89
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=100
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=12
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=12
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=12
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=12
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=12
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=23
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=12
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=12
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=56
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=34
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=23
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=23
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=23
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=23
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=34
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=12
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=23
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=23
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=76
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=100
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=1
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=1
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=76
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=100
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=1
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=12
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=23
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=34
+                ),
+            ],
+        ),
+        FeedbackRequest(
+            prompt="test_prompt",
+            task_type="test_task",
+            criteria_types=[criteria],
+            expire_at="",
+            completion_responses=[
+                CompletionResponses(
+                    model="a", completion=a.completion, completion_id="a", score=1
+                ),
+                CompletionResponses(
+                    model="b", completion=b.completion, completion_id="b", score=23
+                ),
+                CompletionResponses(
+                    model="c", completion=c.completion, completion_id="c", score=76
+                ),
+                CompletionResponses(
+                    model="d", completion=d.completion, completion_id="d", score=100
+                ),
+            ],
+        ),
+    ]
+
+    import matplotlib.pyplot as plt
+
+    scores = Scoring.ground_truth_score_V1(criteria, gt, miner_responses)
+    scores = [score / sum(scores) for score in scores]  # Normalize to ensure sum is 1
+
+    plt.figure(figsize=(10, 6))
+    plt.bar(range(len(scores)), scores)
+    plt.xlabel("Miner Response Index")
+    plt.ylabel("Score")
+    plt.title("Ground Truth Scores")
+    plt.show()
+
+
+if __name__ == "__main__":
+    _test_ground_truth_score_v1()

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -75,6 +75,8 @@ def _get_ground_truth_by_criteria(criteria, model_with_score_sorted):
 
 
 def minmax_scale(tensor: torch.Tensor | np.ndarray) -> torch.Tensor:
+    if isinstance(tensor, np.ndarray):
+        tensor = torch.from_numpy(tensor)
     min = tensor.min()
     max = tensor.max()
     return (tensor - min) / (max - min)
@@ -477,14 +479,15 @@ class Scoring:
 
                 continue
 
-            if isinstance(criteria, RankingCriteria):
-                gt_score = Scoring.spm_ground_truth(
-                    criteria, request, valid_miner_responses
-                )
-            else:
-                gt_score = Scoring.ground_truth_score_V1(
-                    criteria, request, valid_miner_responses
-                )
+            # if isinstance(criteria, RankingCriteria):
+            #     gt_score = Scoring.spm_ground_truth(
+            #         criteria, request, valid_miner_responses
+            #     )
+            if not isinstance(criteria, MultiScoreCriteria):
+                raise NotImplementedError("Only multi-score criteria is supported atm")
+            gt_score = Scoring.ground_truth_score_V1(
+                criteria, request.ground_truth, valid_miner_responses
+            )
 
             # TODO @dev add heuristics once scoring is stable
             # consensus_score = Scoring.consensus_score(

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -332,7 +332,7 @@ class Scoring:
         # use minmax scale to ensure ground truth is in the range [0, 1]
         ground_truth_arr = minmax_scale(
             np.array([rank for _, rank in cid_with_rank_sorted])
-        )
+        ).numpy()
         logger.debug(f"scoring: ground truth\n{ground_truth_arr}")
 
         logger.info(f"scoring: Miner outputs\n{miner_outputs}")
@@ -458,6 +458,9 @@ class Scoring:
         """Combines both consensus score and difference with ground truths scoring to output a final score per miner"""
         criteria_to_miner_scores = defaultdict(Score)
         hotkey_to_final_score: dict[str, float] = defaultdict(float)
+        logger.trace(
+            f"Calculating scores for miner responses ... {len(miner_responses)}"
+        )
         for criteria in criteria_types:
             # valid responses
             valid_miner_responses = []
@@ -484,6 +487,8 @@ class Scoring:
             # #         criteria, request, valid_miner_responses
             # #     )
 
+            logger.debug(f"Got {len(valid_miner_responses)} valid responses")
+
             if not isinstance(criteria, MultiScoreCriteria):
                 raise NotImplementedError("Only multi-score criteria is supported atm")
             gt_score = Scoring.ground_truth_score_V1(
@@ -495,7 +500,12 @@ class Scoring:
             #     criteria, request, valid_miner_responses
             # )
 
-            consensus_score = np.zeros(len(valid_miner_responses))
+            # dummy for now
+            consensus_score = ConsensusScore(
+                score=torch.zeros(len(valid_miner_responses)),
+                mse_by_miner=torch.zeros(len(valid_miner_responses)),
+                icc_by_miner=torch.zeros(len(valid_miner_responses)),
+            )
 
             for i, r in enumerate(valid_miner_responses):
                 # consensus = 0.2 * consensus_score.score[i]

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -445,15 +445,23 @@ def _map_ground_truth_rank_to_score(
         min_score: int | float,
         max_score: int | float,
     ):
-        return rank / (max_rank - min_rank) * (max_score - min_score) + min_score
+        # invert the rank because rank with lower number
+        # i.e. rank 1 is best, rank 3 is worst (0-indexed)
+        inverted_rank = max_rank - rank + min_rank
+        return (
+            inverted_rank / (max_rank - min_rank) * (max_score - min_score) + min_score
+        )
 
     completion_id_score_tuples: list[tuple[str, float]] = []
+
+    min_rank = min(list(unique_ranks))
+    max_rank = max(list(unique_ranks))
 
     for completion_id, rank in list(ground_truth.items()):
         score = convert_rank_to_score(
             rank,
-            min(list(unique_ranks)),
-            max(list(unique_ranks)),
+            min_rank,
+            max_rank,
             criteria.min,
             criteria.max,
         )

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -470,19 +470,20 @@ class Scoring:
                     continue
                 valid_miner_responses.append(response)
 
-            if len(valid_miner_responses) < 2:
-                logger.warning(
-                    f"Skipping scoring for request id: {request.request_id} as not enough valid responses"
-                )
-                for r in valid_miner_responses:
-                    hotkey_to_final_score[r.axon.hotkey] = 0.0
-
-                continue
-
-            # if isinstance(criteria, RankingCriteria):
-            #     gt_score = Scoring.spm_ground_truth(
-            #         criteria, request, valid_miner_responses
+            # if len(valid_miner_responses) < 2:
+            #     logger.warning(
+            #         f"Skipping scoring for request id: {request.request_id} as not enough valid responses"
             #     )
+            #     for r in valid_miner_responses:
+            #         hotkey_to_final_score[r.axon.hotkey] = 0.0
+
+            #     continue
+
+            # # if isinstance(criteria, RankingCriteria):
+            # #     gt_score = Scoring.spm_ground_truth(
+            # #         criteria, request, valid_miner_responses
+            # #     )
+
             if not isinstance(criteria, MultiScoreCriteria):
                 raise NotImplementedError("Only multi-score criteria is supported atm")
             gt_score = Scoring.ground_truth_score_V1(

--- a/dojo/__init__.py
+++ b/dojo/__init__.py
@@ -29,7 +29,6 @@ __spec_version__ = (
     + (1 * int(version_split[2]))
 )
 
-# Import all submodules.
 
 VALIDATOR_MIN_STAKE = 20000
 TASK_DEADLINE = 6 * 60 * 60
@@ -41,6 +40,7 @@ VALIDATOR_UPDATE_SCORE = 3600
 VALIDATOR_STATUS = 60
 MINER_STATUS = 60
 DOJO_TASK_MONITORING = 60
+assert VALIDATOR_UPDATE_SCORE > TASK_DEADLINE
 
 
 def get_dojo_api_base_url() -> str:

--- a/main_validator.py
+++ b/main_validator.py
@@ -29,7 +29,7 @@ async def lifespan(app: FastAPI):
     validator.executor.shutdown(wait=True)
     wandb.finish()
     validator.save_state()
-    await SyntheticAPI._session.close()
+    await SyntheticAPI.close_session()
     await disconnect_db()
 
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -810,6 +810,12 @@ class Validator(BaseNeuron):
         except Exception as e:
             logger.error(f"Failed to save validator state: {e}")
 
+    def save_state(self):
+        try:
+            self.loop.run_until_complete(self._save_state())
+        except Exception as e:
+            logger.error(f"Failed to save validator state: {e}")
+
     async def _load_state(self):
         try:
             await connect_db()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -202,7 +202,7 @@ class Validator(BaseNeuron):
                             mean_weighted_gt_scores = (
                                 torch.stack(
                                     [
-                                        miner_scores.ground_truth.score
+                                        miner_scores.ground_truth
                                         for miner_scores in criteria_to_miner_score.values()
                                     ]
                                 )

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -610,42 +610,32 @@ class Validator(BaseNeuron):
                 "Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions."
             )
 
-        # Calculate the average reward for each uid across non-zero values.
-        # Replace any NaN values with 0.
-        normalized_weights = F.normalize(self.scores.cpu(), p=1, dim=0)
-
-        logger.debug(f"Raw scores: {self.scores}")
-        logger.debug(f"normalized weights: {normalized_weights}")
-        logger.debug(f"normalized weights uids: {self.metagraph.uids}")
         logger.info("Attempting to set weights")
 
         safe_uids = self.metagraph.uids
         if isinstance(self.metagraph.uids, np.ndarray):
-            pass
+            safe_uids = torch.from_numpy(safe_uids).to("cpu")
         elif isinstance(self.metagraph.uids, torch.Tensor):
-            safe_uids = self.metagraph.uids.to("cpu").numpy()
+            pass
+
+        # ensure sum = 1
+        normalized_weights = F.normalize(self.scores.cpu(), p=1, dim=0)
 
         safe_normalized_weights = normalized_weights
         if isinstance(normalized_weights, np.ndarray):
-            pass
+            safe_normalized_weights = torch.from_numpy(normalized_weights).to("cpu")
         elif isinstance(normalized_weights, torch.Tensor):
-            safe_normalized_weights = normalized_weights.to("cpu").numpy()
+            pass
 
-        # Process the raw weights to final_weights via subtensor limitations.
-        (
-            processed_weight_uids,
-            processed_weights,
-        ) = bt.utils.weight_utils.process_weights_for_netuid(  # type: ignore
-            uids=safe_uids,
-            weights=safe_normalized_weights,
-            netuid=self.config.netuid,
-            subtensor=self.subtensor,
-            metagraph=self.metagraph,
-        )
-        logger.debug(f"processed weights {processed_weights}")
-        logger.debug(f"processed weights uids {processed_weight_uids}")
+        min_allowed_weights = self.subtensor.min_allowed_weights(self.config.netuid)
+        max_weight_limit = self.subtensor.max_weight_limit(self.config.netuid)
+        logger.debug(f"min_allowed_weights: {min_allowed_weights}")
+        logger.debug(f"max_weight_limit: {max_weight_limit}")
 
-        self.set_weights_in_thread(processed_weight_uids, processed_weights)
+        logger.debug("Attempting to set weights")
+        logger.debug(f"weights: {safe_normalized_weights}")
+        logger.debug(f"uids: {safe_uids}")
+        self.set_weights_in_thread(safe_uids, safe_normalized_weights)
         return
 
     def set_weights_in_thread(self, uids: torch.Tensor, weights: torch.Tensor):
@@ -819,14 +809,6 @@ class Validator(BaseNeuron):
             logger.debug(f"No need to to save validator state: {e}")
         except Exception as e:
             logger.error(f"Failed to save validator state: {e}")
-
-    def save_state(self):
-        """Saves the state of the validator to a file."""
-        try:
-            self.loop.run_until_complete(self._save_state())
-        except Exception as e:
-            logger.error(f"Failed to save validator state: {e}")
-            pass
 
     async def _load_state(self):
         try:

--- a/tests/unit_testing/test_scoring.py
+++ b/tests/unit_testing/test_scoring.py
@@ -195,18 +195,10 @@ def test_ground_truth_leaderboard_data_normal(mock_get_leaderboard_scores):
             ]
         )
 
-        assert not np.isnan(
-            gt_score.score
-        ).any(), "overall score does not contain NaN values"
-        assert not np.isinf(
-            gt_score.score
-        ).any(), "overall score does not contain inf values"
-        assert not np.isnan(
-            gt_score.raw_scores_by_miner
-        ).any(), "overall score does not contain NaN values"
-        assert not np.isinf(
-            gt_score.raw_scores_by_miner
-        ).any(), "overall score does not contain inf values"
+        assert not np.isnan(gt_score).any(), "overall score does not contain NaN values"
+        assert not np.isinf(gt_score).any(), "overall score does not contain inf values"
+        assert not np.isnan(gt_score).any(), "overall score does not contain NaN values"
+        assert not np.isinf(gt_score).any(), "overall score does not contain inf values"
 
 
 @pytest.mark.skip(reason="Placeholder test, not implemented yet")
@@ -408,19 +400,16 @@ def test_spearman_correlation(scoring_module):
 
         # Ensure no NaN values
         assert not np.isnan(
-            spearman_score.score
+            spearman_score
         ).any(), "Spearman score should not contain NaN values"
 
         # Ensure no inf values
         assert not np.isinf(
-            spearman_score.score
+            spearman_score
         ).any(), "Spearman score should not contain inf values"
 
         # Check if Spearman scores are valid between -1 and 1
-        assert torch.all(
-            (spearman_score.raw_scores_by_miner >= -1)
-            & (spearman_score.raw_scores_by_miner <= 1)
-        )
+        assert torch.all((spearman_score >= -1) & (spearman_score <= 1))
 
 
 def test_spearman_correlation_known_values(scoring_module):
@@ -443,13 +432,13 @@ def test_spearman_correlation_known_values(scoring_module):
 
         # Ensure that the raw scores are cast to float32 before comparison
         assert torch.allclose(
-            spearman_score.raw_scores_by_miner[0].float(),  # Cast to float32
+            spearman_score[0],
             torch.tensor(miner_a_spearman, dtype=torch.float32),
             atol=1e-6,
-        ), f"Expected Spearman score for Miner A: {miner_a_spearman}, got: {spearman_score.raw_scores_by_miner[0]}"
+        ), f"Expected Spearman score for Miner A: {miner_a_spearman}, got: {spearman_score[0]}"
 
         assert torch.allclose(
-            spearman_score.raw_scores_by_miner[1].float(),  # Cast to float32
+            spearman_score[1],
             torch.tensor(miner_b_spearman, dtype=torch.float32),
             atol=1e-6,
-        ), f"Expected Spearman score for Miner B: {miner_b_spearman}, got: {spearman_score.raw_scores_by_miner[1]}"
+        ), f"Expected Spearman score for Miner B: {miner_b_spearman}, got: {spearman_score[1]}"


### PR DESCRIPTION
- purely use ground truth score
- change to L1 norm instead of L2 norm
- normalize ground truth and each of miners outputs
- refactor Score object to be simpler

TODO 
- shift test logic in scoring.py to unit tests