### PR TITLE
fix: set weights, mini batching update miner responses, update logs

### DIFF
--- a/commons/orm.py
+++ b/commons/orm.py
@@ -328,6 +328,7 @@ class ORM:
         num_batches = round(len(miner_responses) / batch_size)
         num_failed_batches = 0
         failed_batch_indices = []
+        batch_id = 0
         for i in range(0, len(miner_responses), batch_size):
             safe_lim = min(len(miner_responses), i + batch_size)
             try:
@@ -396,14 +397,16 @@ class ORM:
                             )
 
                 logger.debug(
-                    f"Updating completion responses: updated batch {i}/{num_batches} "
+                    f"Updating completion responses: updated batch {batch_id+1}/{num_batches} "
                 )
             except Exception as e:
                 logger.error(
-                    f"Updating completion responses: failed for batch {i}/{num_batches}, error: {e}"
+                    f"Updating completion responses: failed for batch {batch_id+1}/{num_batches}, error: {e}"
                 )
                 num_failed_batches += 1
                 failed_batch_indices.extend(range(i, safe_lim))
+            finally:
+                batch_id += 1
 
             await asyncio.sleep(0.1)
 

--- a/commons/orm.py
+++ b/commons/orm.py
@@ -15,7 +15,7 @@ from commons.exceptions import (
     UnexpiredTasksAlreadyProcessed,
 )
 from commons.utils import datetime_as_utc
-from database.client import db, transaction
+from database.client import prisma, transaction
 from database.mappers import (
     map_child_feedback_request_to_model,
     map_completion_response_to_model,
@@ -335,7 +335,7 @@ class ORM:
 
                 # NOTE: @dev we must nest the transaction so after __aexit__ is
                 # called (when no exceptions occur) then tx.commit() is called
-                async with db.tx(timeout=timedelta(seconds=10)) as tx:
+                async with prisma.tx(timeout=timedelta(seconds=10)) as tx:
                     # find the feedback request ids
                     miner_hotkeys = []
                     for miner_response in batch_responses:

--- a/commons/orm.py
+++ b/commons/orm.py
@@ -1,6 +1,7 @@
 import asyncio
 import gc
 import json
+import math
 from datetime import datetime, timedelta, timezone
 from typing import AsyncGenerator, List
 
@@ -325,7 +326,11 @@ class ORM:
         """Update the miner's provided rank_id / scores etc. for a given request id that it is responding to validator. This exists because over the course of a task, a miner may recruit multiple workers and we
         need to recalculate the average score / rank_id etc. across all workers.
         """
-        num_batches = round(len(miner_responses) / batch_size)
+        if not len(miner_responses):
+            logger.debug("Updating completion responses: nothing to update, skipping.")
+            return True, []
+
+        num_batches = math.ceil(len(miner_responses) / batch_size)
         num_failed_batches = 0
         failed_batch_indices = []
         batch_id = 0

--- a/commons/orm.py
+++ b/commons/orm.py
@@ -13,7 +13,7 @@ from commons.exceptions import (
     UnexpiredTasksAlreadyProcessed,
 )
 from commons.utils import datetime_as_utc
-from database.client import transaction
+from database.client import db, transaction
 from database.mappers import (
     map_child_feedback_request_to_model,
     map_completion_response_to_model,
@@ -324,7 +324,7 @@ class ORM:
         need to recalculate the average score / rank_id etc. across all workers.
         """
         try:
-            async with transaction() as tx:
+            async with db.tx(timeout=timedelta(seconds=10)) as tx:
                 # find the feedback request ids
                 miner_hotkeys = []
                 for miner_response in miner_responses:

--- a/commons/utils.py
+++ b/commons/utils.py
@@ -43,7 +43,7 @@ def _terminal_plot(
         y = y_copy
 
     # plot actual points first
-    plotext.scatter(x, y, marker="fhd", color="red")  # show the points exactly
+    plotext.scatter(x, y, marker="bitcoin", color="orange")  # show the points exactly
     plotext.title(title)
     plotext.ticks_color("red")
     plotext.xfrequency(1)  # Set frequency to 1 for better alignment

--- a/dojo/__init__.py
+++ b/dojo/__init__.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from dojo.utils.config import source_dotenv
+from dojo.utils.config import get_config, source_dotenv
 
 source_dotenv()
 
@@ -41,6 +41,17 @@ VALIDATOR_STATUS = 60
 MINER_STATUS = 60
 DOJO_TASK_MONITORING = 60
 assert VALIDATOR_UPDATE_SCORE < TASK_DEADLINE
+
+if get_config().fast_mode:
+    print("Running in fast mode for testing purposes...")
+    VALIDATOR_MIN_STAKE = 20000
+    TASK_DEADLINE = 180
+    VALIDATOR_RUN = 60
+    VALIDATOR_HEARTBEAT = 15
+    VALIDATOR_UPDATE_SCORE = 120
+    VALIDATOR_STATUS = 1200
+    MINER_STATUS = 1200
+    DOJO_TASK_MONITORING = 15
 
 
 def get_dojo_api_base_url() -> str:

--- a/dojo/utils/config.py
+++ b/dojo/utils/config.py
@@ -145,13 +145,6 @@ def add_args(parser):
     )
 
     parser.add_argument(
-        "--neuron.epoch_length",
-        type=int,
-        help="The default epoch length (how often we set weights, measured in 12 second blocks).",
-        default=100,
-    )
-
-    parser.add_argument(
         "--api.port",
         type=int,
         help="FastAPI port for uvicorn to run on, should be different from axon.port as these will serve external requests.",
@@ -174,6 +167,25 @@ def add_args(parser):
         "--service",
         choices=["miner-decentralised", "miner-centralised", "validator"],
         help="Specify the service to run (miner or validator) for auto_updater.",
+    )
+
+    parser.add_argument(
+        "--fast_mode",
+        action="store_true",
+        help="Whether to run in fast mode, for developers to test locally.",
+    )
+
+    epoch_length = 100
+    known_args, _ = parser.parse_known_args()
+    if known_args := vars(known_args):
+        if known_args["fast_mode"]:
+            epoch_length = 10
+
+    parser.add_argument(
+        "--neuron.epoch_length",
+        type=int,
+        help="The default epoch length (how often we set weights, measured in 12 second blocks).",
+        default=epoch_length,
     )
 
     if neuron_type == "validator":

--- a/main_validator.py
+++ b/main_validator.py
@@ -27,6 +27,7 @@ async def lifespan(app: FastAPI):
     logger.info("Performing shutdown tasks...")
     validator._should_exit = True
     validator.executor.shutdown(wait=True)
+    validator.subtensor.substrate.close()
     wandb.finish()
     await validator.save_state()
     await SyntheticAPI.close_session()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1013,13 +1013,12 @@ class Validator:
 
                     for task in task_batch:
                         request_id = task.request.request_id
-                        miner_responses = task.miner_responses
 
                         obfuscated_to_real_model_id = await ORM.get_real_model_ids(
                             request_id
                         )
 
-                        for miner_response in miner_responses:
+                        for miner_response in task.miner_responses:
                             if (
                                 not miner_response.axon
                                 or not miner_response.axon.hotkey
@@ -1058,25 +1057,25 @@ class Validator:
                                 if model_id in model_id_to_avg_score:
                                     completion.score = model_id_to_avg_score[model_id]
 
-                            # Update miner responses in the database
-                            success = await ORM.update_miner_completions_by_request_id(
-                                request_id, task.miner_responses
-                            )
+                        # Update miner responses in the database
+                        success = await ORM.update_miner_completions_by_request_id(
+                            request_id, task.miner_responses
+                        )
 
-                            if success:
-                                hotkeys = [m.axon.hotkey for m in task.miner_responses]
-                                uids = [
-                                    self.metagraph.hotkeys.index(hotkey)
-                                    for hotkey in hotkeys
-                                    if hotkey in self.metagraph.hotkeys
-                                ]
-                                logger.success(
-                                    f"Successfully updated miner completions for request id: {request_id}, uids: {uids}"
-                                )
-                            else:
-                                logger.error(
-                                    f"Failed to update miner completions for request id: {request_id}, uids: {uids}"
-                                )
+                        if success:
+                            hotkeys = [m.axon.hotkey for m in task.miner_responses]
+                            uids = [
+                                self.metagraph.hotkeys.index(hotkey)
+                                for hotkey in hotkeys
+                                if hotkey in self.metagraph.hotkeys
+                            ]
+                            logger.success(
+                                f"Successfully updated miner completions for request id: {request_id}, uids: {uids}"
+                            )
+                        else:
+                            logger.error(
+                                f"Failed to update miner completions for request id: {request_id}, uids: {uids}"
+                            )
                         await asyncio.sleep(0.2)
             except NoNewUnexpiredTasksYet as e:
                 logger.info(f"No new unexpired tasks yet: {e}")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -687,7 +687,7 @@ class Validator:
         # dependent on underlying `set_weights` call
         era = 5
         block_time = 12
-        total_max_wait = (max_attempts + 1) + era * block_time
+        total_max_wait = (max_attempts + 1) * era * block_time
         result, message = False, ""
         try:
             result, message = await asyncio.wait_for(


### PR DESCRIPTION
- update instead of deleting/creating completion response records
- batching for miner completion responses
- increase transaction timeout
- removed log spam
- add fast_mode cli arg
- separate asyncio locks for uids, scores/weights
- add asyncio wait_for to prevent set_weights hanging
- set wait_for_finalization=False