### PR TITLE
Fix: negative stride error from scoring

### DIFF
--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -414,7 +414,6 @@ class Scoring:
         )
 
         miner_outputs = miner_outputs_normalised
-        logger.debug(f"scoring: raw miner outputs with nans\n{miner_outputs}")
 
         # use minmax scale to ensure ground truth is in the range [0, 1]
         ground_truth_arr = minmax_scale(
@@ -426,7 +425,6 @@ class Scoring:
         # after minmax scale: [0, 0.33, 0.667, 1]
         # but we want the reverse, so: [1, 0.667, 0.33, 0], since cid1 is the best
         ground_truth_arr = ground_truth_arr[::-1]
-        logger.debug(f"scoring: ground truth\n{ground_truth_arr}")
 
         logger.info(f"scoring: Miner outputs\n{miner_outputs}")
         logger.info(f"scoring: Ground truth\n{ground_truth_arr}")

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -79,8 +79,11 @@ def _reward_cubic(
     # shape: (num_miners,)
     # number range [-1, 1]
     x = F.cosine_similarity(
-        torch.from_numpy(miner_outputs), torch.from_numpy(ground_truth), dim=1
+        torch.from_numpy(miner_outputs.copy()),
+        torch.from_numpy(ground_truth.copy()),
+        dim=1,
     ).numpy()
+
     # Convert nans to -1 to send it to the bottom
     x = np.where(np.isnan(x), -1, x)
 
@@ -455,7 +458,7 @@ class Scoring:
             logger.debug(f"scoring: error calculating segment sums: {e}")
             pass
 
-        return torch.from_numpy(cubic_reward)
+        return torch.from_numpy(cubic_reward.copy())
 
     @staticmethod
     def cmp_ground_truth(


### PR DESCRIPTION
- added .copy() when creating tensors from numpy array to fix negative stride errors.
- removed duplicate logs in scoring.py