### PR TITLE
fix: wandb now storing final scores correctly

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1307,7 +1307,7 @@ class Validator:
         )
 
         score_data = {
-            "scores_by_hotkey": hotkey_to_score,
+            "scores_by_hotkey": [hotkey_to_score],
             "mean": {
                 "consensus": mean_weighted_consensus_scores,
                 "ground_truth": mean_weighted_gt_scores,


### PR DESCRIPTION
- wrapped hotkey_to_score dict in a list so wandb doesnt store it all as separate columns. 