### PR TITLE
Fix/wandb missing final scores

### DIFF
--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -641,8 +641,8 @@ class Scoring:
                 ground_truth = gt_score[i]
 
                 # NOTE: just use ground truth for now
-                hotkey_to_final_score[r.axon.hotkey] = ground_truth / len(
-                    criteria_types
+                hotkey_to_final_score[r.axon.hotkey] = float(
+                    ground_truth / len(criteria_types)
                 )
 
             criteria_to_miner_scores[criteria.type] = Score(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1307,7 +1307,7 @@ class Validator:
         )
 
         score_data = {
-            "scores_by_hotkey": hotkey_to_score,
+            "scores_by_hotkey": [hotkey_to_score],
             "mean": {
                 "consensus": mean_weighted_consensus_scores,
                 "ground_truth": mean_weighted_gt_scores,


### PR DESCRIPTION
- final scores weren't showing on wandb because they were of type tensor.float. 
- casted them to primitive float and its fixed. 