### PR TITLE
chore: included btcli in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "aiohttp==3.10.11",
-  "bittensor @ git+https://github.com/opentensor/bittensor.git@release/8.5.1",
+  "bittensor[cli] @ git+https://github.com/opentensor/bittensor.git@release/8.5.1",
   "fastapi==0.110.1",
   "httpx==0.27.0",
   "loguru==0.7.2",


### PR DESCRIPTION
- since bittensor v8, btcli is not included in the sdk installation. Modified the dependencies to include btcli.