### PR TITLE
fix: commit reveal param, enable watchtower (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.12.0](https://github.com/tensorplex-labs/dojo/compare/v1.11.2...v1.12.0) (2025-05-14)
+
+### Features
+
+* kami ([#185](https://github.com/tensorplex-labs/dojo/issues/185)) ([eccac9e](https://github.com/tensorplex-labs/dojo/commit/eccac9e7ffe52cc4b97610cc31da2f5e0d0c6e23))
+
 ## [1.11.2](https://github.com/tensorplex-labs/dojo/compare/v1.11.1...v1.11.2) (2025-04-29)
 
 ### Bug Fixes

--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -76,6 +76,8 @@ services:
   kami:
     container_name: kami
     image: ghcr.io/tensorplex-labs/kami:main
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     env_file:
       - .env
     expose:

--- a/docker-compose.validator.yaml
+++ b/docker-compose.validator.yaml
@@ -96,7 +96,7 @@ services:
     restart: on-failure
     labels:
       com.centurylinklabs.watchtower.enable: "true"
-      com.centurylinklabs.watchtower.depends-on: "synthetic-api,postgres"
+      com.centurylinklabs.watchtower.depends-on: "synthetic-api,postgres,kami"
     env_file:
       - .env
     volumes:

--- a/dojo/kami/kami.py
+++ b/dojo/kami/kami.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from dojo.kami.types import (
     AxonInfo,
+    CommitRevealPayload,
     ServeAxonPayload,
     SetWeightsPayload,
     SubnetHyperparameters,
@@ -256,15 +257,23 @@ class Kami:
                 subnet_reveal_period_epochs=reveal_period,
             )
 
-            print(f"Commit for reveal: {commit_for_reveal}")
+            print(f"Commit for reveal: {commit_for_reveal.hex()}")  # type: ignore
             print(f"Reveal round: {reveal_round}")
 
-            cr_payload: dict[str, int | str] = {
-                "netuid": payload.netuid,
-                "commit": commit_for_reveal.hex(),  # type: ignore
-                "reveal_round": reveal_round,
-            }
+            if not commit_for_reveal or not reveal_round:
+                raise ValueError(
+                    "Failed to generate commit for reveal. Ensure that tempo and reveal round are set correctly."
+                )
 
-            return await self.post("chain/set-commit-reveal-weights", data=cr_payload)
+            hex_commit: str = commit_for_reveal.hex()  # type: ignore
+            cr_payload: CommitRevealPayload = CommitRevealPayload(
+                netuid=payload.netuid,
+                commit=hex_commit,
+                revealRound=reveal_round,
+            )
 
-        return await self.post("chain/set-weights", data=payload.model_dump())
+            return await self.post(
+                "chain/set-commit-reveal-weights",
+                data=cr_payload.model_dump(),  # type: ignore TODO: Fix type ignore
+            )
+        return await self.post("chain/set-weights", data=payload.model_dump())  # type: ignore TODO: Fix type ignore

--- a/dojo/kami/types.py
+++ b/dojo/kami/types.py
@@ -14,7 +14,9 @@ class SubnetHyperparameters(BaseModel):
     maxDifficulty: int
     difficulty: int
     weightsVersion: int
-    weightsRateLimit: int
+    weightsRateLimit: (
+        int | str
+    )  # TODO: fix on kami side for netuid 0 to return max u64 integer
     adjustmentInterval: int
     activityCutoff: int
     registrationAllowed: bool
@@ -66,8 +68,8 @@ class SetWeightsPayload(BaseModel):
 
 class CommitRevealPayload(BaseModel):
     netuid: int
-    commit: int | bytes
-    reveal_round: int
+    commit: str
+    revealRound: int
 
 
 class MovingPrice(BaseModel):
@@ -135,7 +137,9 @@ class SubnetMetagraph(BaseModel):
     # # TODO: not sure if this field is present
     # maxAllowedWeights: int
     weightsVersion: int
-    weightsRateLimit: int
+    weightsRateLimit: (
+        int | str
+    )  # TODO: fix on kami side for netuid 0 to return max u64 integer
     activityCutoff: int
     maxValidators: int
     numUids: int

--- a/entrypoints/analytics_upload.py
+++ b/entrypoints/analytics_upload.py
@@ -27,9 +27,7 @@ from dojo.protocol import AnalyticsData, AnalyticsPayload
 VALIDATOR_API_BASE_URL = os.getenv("VALIDATOR_API_BASE_URL")
 
 
-async def _get_all_miner_hotkeys(
-    subnet_metagraph: SubnetMetagraph, root_metagraph: SubnetMetagraph
-) -> List[str]:
+async def _get_all_miner_hotkeys(subnet_metagraph: SubnetMetagraph) -> List[str]:
     """
     returns a list of all metagraph hotkeys with stake less than VALIDATOR_MIN_STAKE
     """
@@ -216,8 +214,7 @@ async def run_analytics_upload(
         validator_hotkey = wallet.hotkey.ss58_address
 
         subnet_metagraph = await kami.get_metagraph(config.netuid)  # type: ignore
-        root_metagraph = await kami.get_metagraph(0)
-        all_miners = await _get_all_miner_hotkeys(subnet_metagraph, root_metagraph)
+        all_miners = await _get_all_miner_hotkeys(subnet_metagraph)
 
         # 1. collect processed tasks from db
         anal_data: AnalyticsPayload = await _get_task_data(


### PR DESCRIPTION
* fix: commit reveal round payload name mismatched by specifying the correct model type, temp hotfix for netuid 0 metagraph calls.

* fix: no longer calling root metagraph as not required

* chore: enable watchtower for kami