### PR TITLE
fix: drand package and visual augments support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.12.1](https://github.com/tensorplex-labs/dojo/compare/v1.12.0...v1.12.1) (2025-05-15)
+
+### Bug Fixes
+
+* commit reveal param, enable watchtower ([#189](https://github.com/tensorplex-labs/dojo/issues/189)) ([badbb6a](https://github.com/tensorplex-labs/dojo/commit/badbb6acf02392bb504849a69ffcdced10bce68d)), closes [#185](https://github.com/tensorplex-labs/dojo/issues/185)
+
 ## [1.12.0](https://github.com/tensorplex-labs/dojo/compare/v1.11.2...v1.12.0) (2025-05-14)
 
 ### Features

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    build-essential curl git ca-certificates openssl \
+    build-essential curl git ca-certificates openssl clang libssl-dev llvm libudev-dev make pkg-config protobuf-compiler\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \

--- a/dojo/kami/kami.py
+++ b/dojo/kami/kami.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Dict
 
 import aiohttp
-from bittensor_commit_reveal import get_encrypted_commit  # type: ignore
+from bittensor_drand import get_encrypted_commit  # type: ignore
 from loguru import logger
 
 from dojo.kami.types import (
@@ -242,7 +242,7 @@ class Kami:
                     "Tempo and reveal round must be greater than 0 for commit reveal weights."
                 )
 
-            print(
+            logger.info(
                 f"Commit reveal weights enabled: tempo: {tempo}, reveal_period: {reveal_period}"
             )
 
@@ -257,18 +257,17 @@ class Kami:
                 subnet_reveal_period_epochs=reveal_period,
             )
 
-            print(f"Commit for reveal: {commit_for_reveal.hex()}")  # type: ignore
-            print(f"Reveal round: {reveal_round}")
+            logger.info(f"Commit for reveal: {commit_for_reveal.hex()}")  # type: ignore
+            logger.info(f"Reveal round: {reveal_round}")
 
             if not commit_for_reveal or not reveal_round:
                 raise ValueError(
                     "Failed to generate commit for reveal. Ensure that tempo and reveal round are set correctly."
                 )
 
-            hex_commit: str = commit_for_reveal.hex()  # type: ignore
             cr_payload: CommitRevealPayload = CommitRevealPayload(
                 netuid=payload.netuid,
-                commit=hex_commit,
+                commit=commit_for_reveal.hex(),
                 revealRound=reveal_round,
             )
 

--- a/dojo/protocol.py
+++ b/dojo/protocol.py
@@ -53,7 +53,6 @@ CriteriaType = ScoreCriteria
 class CodeFileObject(BaseModel):
     filename: str = Field(description="Name of the file")
     content: str = Field(description="Content of the file which can be code or json")
-    language: str = Field(description="Programming language of the file")
 
 
 class CodeAnswer(BaseModel):

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -252,8 +252,8 @@ class Validator(aobject):
             safe_normalized_weights.numpy(),
         )
 
-        logger.info(f"final weights:\n{final_weights}")
-        logger.info(f"final uids:\n{final_uids}")
+        logger.info(f"Final weights:\n{final_weights}")
+        logger.info(f"Final uids:\n{final_uids}")
 
         _terminal_plot(
             f"final weights, block: {self.block}",
@@ -310,12 +310,13 @@ class Validator(aobject):
                 # except asyncio.TimeoutError:
                 #     pass
 
-                logger.info(f"Converting weights and uids for emit: {uids}, {weights}")
-
                 uids, weights = convert_weights_and_uids_for_emit(
                     uids=uids,
                     weights=weights,
                 )
+
+                logger.info(f"Converted uids: {uids}")
+                logger.info(f"Converted weights: {weights}")
 
                 payload = SetWeightsPayload(
                     netuid=self.config.netuid,  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "aiohttp==3.10.11",
   "bittensor @ git+https://github.com/opentensor/bittensor.git@release/9.0.0",
   "bittensor-cli @ git+https://github.com/opentensor/btcli.git@release/9.0.0",
+  "bittensor_drand @ git+https://github.com/opentensor/bittensor-drand.git@release/0.5.0",
   "fastapi==0.110.1",
   "httpx==0.27.0",
   "loguru==0.7.2",


### PR DESCRIPTION
on syn-api we removed language field from FileObject type. 

Dojo is then validating syn-api outputs against a copy of that type, so we need to update the FileObject defintion on dojo to keep it functional with the latest syn-api. 