### PR TITLE
fix: backup scores; removed lang field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,10 +191,11 @@ database/prisma/
 
 # scores data
 scores/*.pt
+scores/*.pt.bak
+scores/*.pt.bak.*
 
 # migration logs
 migration_logs/
 
 uv.lock
 .python-version
-

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ miner-pull:
 	docker compose -f docker-compose.miner.yaml pull --include-deps
 
 validator-down:
-	-@docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak || true
+	-@docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt || true
 	docker compose -f docker-compose.validator.yaml down
 
 miner-down:
@@ -62,7 +62,7 @@ miner:
 	docker compose -f docker-compose.miner.yaml up -d miner
 
 validator:
-	-@docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak || true
+	-@docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt || true
 	docker compose -f docker-compose.validator.yaml up -d validator
 
 validator-up-deps:

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ miner-pull:
 	docker compose -f docker-compose.miner.yaml pull --include-deps
 
 validator-down:
+	docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak
 	docker compose -f docker-compose.validator.yaml down
 
 miner-down:
@@ -61,6 +62,7 @@ miner:
 	docker compose -f docker-compose.miner.yaml up -d miner
 
 validator:
+	docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak
 	docker compose -f docker-compose.validator.yaml up -d validator
 
 validator-up-deps:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ miner-pull:
 	docker compose -f docker-compose.miner.yaml pull --include-deps
 
 validator-down:
-	docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak
+	-@docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak || true
 	docker compose -f docker-compose.validator.yaml down
 
 miner-down:
@@ -62,7 +62,7 @@ miner:
 	docker compose -f docker-compose.miner.yaml up -d miner
 
 validator:
-	docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak
+	-@docker cp validator:/app/scores/miner_scores.pt ./scores/miner_scores.pt.bak || true
 	docker compose -f docker-compose.validator.yaml up -d validator
 
 validator-up-deps:

--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,6 @@ watchtower:
 
 watchtower-down:
 	docker compose -f docker-compose.shared.yaml down watchtower
+
+back-up-scores:
+	docker cp validator:/app/scores/miner_scores.pt scores/miner_scores.pt.bak

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -179,13 +179,13 @@ class Scoring:
         cid_rank_tuples = [
             (completion_id, rank) for completion_id, rank in ground_truth.items()
         ]
-        logger.debug(f"scoring: cid rank tuples\n{cid_rank_tuples}")
+        logger.info(f"scoring: cid rank tuples\n{cid_rank_tuples}")
 
         # Sort cids by rank. In the order, 0 is the best, 1 is the second best, etc.
         cid_with_rank_sorted = sorted(
             cid_rank_tuples, key=lambda x: x[1], reverse=False
         )
-        logger.debug(f"scoring: cid with rank sorted\n{cid_with_rank_sorted}")
+        logger.info(f"scoring: cid with rank sorted\n{cid_with_rank_sorted}")
 
         # sort miner outputs according to ground truth order
         # we're using this because miners receive a shuffled order of the completions

--- a/commons/scoring.py
+++ b/commons/scoring.py
@@ -230,7 +230,9 @@ class Scoring:
             cosine_similarity_scores,
             normalised_cosine_similarity_scores,
             cubic_reward_scores,
-        ) = _reward_cubic(miner_outputs, ground_truth_arr, 0.006, 7, 2, visualize=True)
+        ) = _reward_cubic(
+            miner_outputs_normalised, ground_truth_arr, 0.006, 7, 2, visualize=True
+        )
         logger.debug(f"scoring: cubic reward\n{cubic_reward}")
 
         # normalize to ensure sum is 1

--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -27,6 +27,8 @@ services:
       - .env
     expose:
       - 6379
+    ports:
+      - 6579:6379
     command: >
       sh -c '
       if [ ! -z "$$REDIS_PASSWORD" ] && [ ! -z "$$REDIS_USERNAME" ]; then
@@ -64,6 +66,8 @@ services:
       "
     expose:
       - 5432
+    ports:
+      - 5532:5432
     healthcheck:
       test:
         # looks strange, but double $ (i.e. $$) for variable substitution

--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -27,8 +27,6 @@ services:
       - .env
     expose:
       - 6379
-    ports:
-      - 6579:6379
     command: >
       sh -c '
       if [ ! -z "$$REDIS_PASSWORD" ] && [ ! -z "$$REDIS_USERNAME" ]; then
@@ -66,8 +64,6 @@ services:
       "
     expose:
       - 5432
-    ports:
-      - 5532:5432
     healthcheck:
       test:
         # looks strange, but double $ (i.e. $$) for variable substitution

--- a/docker-compose.validator.yaml
+++ b/docker-compose.validator.yaml
@@ -8,7 +8,6 @@ volumes:
   prisma-pip-cache:
   prisma-binary:
   prisma-client:
-  scores:
 
 networks:
   dojo-validator:
@@ -102,11 +101,11 @@ services:
       - .env
     volumes:
       - ./.env:/app/.env
+      - ./scores:/app/scores
       - $BITTENSOR_DIR:/root/.bittensor
       - prisma-binary:/root/prisma-python
       - prisma-pip-cache:/root/.cache/pip
       - prisma-client:/app/database/prisma
-      - scores:/app/scores
     command: ["validator"]
     networks:
       - dojo-validator

--- a/docker-compose.validator.yaml
+++ b/docker-compose.validator.yaml
@@ -8,6 +8,7 @@ volumes:
   prisma-pip-cache:
   prisma-binary:
   prisma-client:
+  scores:
 
 networks:
   dojo-validator:

--- a/docker-compose.validator.yaml
+++ b/docker-compose.validator.yaml
@@ -105,6 +105,7 @@ services:
       - prisma-binary:/root/prisma-python
       - prisma-pip-cache:/root/.cache/pip
       - prisma-client:/app/database/prisma
+      - scores:/app/scores
     command: ["validator"]
     networks:
       - dojo-validator
@@ -119,6 +120,7 @@ services:
         condition: service_completed_successfully
       kami:
         condition: service_healthy
+
     logging:
       driver: loki
       options:

--- a/dojo/protocol.py
+++ b/dojo/protocol.py
@@ -53,7 +53,6 @@ CriteriaType = ScoreCriteria
 class CodeFileObject(BaseModel):
     filename: str = Field(description="Name of the file")
     content: str = Field(description="Content of the file which can be code or json")
-    language: str = Field(description="Programming language of the file")
 
 
 class CodeAnswer(BaseModel):

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -150,6 +150,11 @@ class Validator(aobject):
 
     async def send_scores(self, synapse: ScoringResult, hotkeys: List[str]):
         """Send consensus score back to miners who participated in the request."""
+        for _, responses in synapse.hotkey_to_completion_responses.items():
+            for response in responses:
+                # Set completion to None to reduce the size of the synapse
+                response.completion = None
+
         miners_uids = await self.get_active_miner_uids()
         metagraph_axons = await self._retrieve_axons(miners_uids)
         axons = [axon for axon in metagraph_axons if axon.hotkey in hotkeys]

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -137,15 +137,6 @@ class Validator(aobject):
         )
 
         await self.check_registered()
-
-        # Run score migration before loading state
-        migration_success = await ScoreStorage.migrate_from_db()
-        if not migration_success:
-            logger.error(
-                "Score migration failed - cannot continue without valid scores"
-            )
-            raise RuntimeError("Score migration failed - validator cannot start")
-
         await self.load_state()
 
     async def send_scores(self, synapse: ScoringResult, hotkeys: List[str]):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added automated backup and copying of score files from the validator Docker container to the local machine, with a new Makefile target for backing up scores.
	- Introduced a new volume mount in the validator service to persist scores data.
- **Bug Fixes**
	- Improved score data handling by clearing completion data before forwarding, reducing memory usage.
- **Refactor**
	- Removed the language field from code file objects.
	- Upgraded certain log statements to info level for better visibility.
- **Chores**
	- Updated .gitignore to exclude backup score files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->