### PR TITLE
fix: update pinned subtensor lite node versions.

### DIFF
--- a/docker-compose.subtensor.yaml
+++ b/docker-compose.subtensor.yaml
@@ -8,7 +8,7 @@ networks:
 
 services:
   common-amd64: &common-amd64 # image: ghcr.io/opentensor/subtensor:v2.0.9-amd64
-    image: ghcr.io/opentensor/subtensor@sha256:83583997be9137c7e13fffce98752fa9a326a4bfabfd933544c14f0b693bc40b #v3.1.0-amd64
+    image: ghcr.io/opentensor/subtensor:v3.1.0-amd64@sha256:054e9c989cd5a43a6f70fe8cf76cc7e8947eaed3d9cbd8b3dd5df047f1e7e346
     build:
       context: .
       dockerfile: Dockerfile
@@ -72,7 +72,7 @@ services:
           --reserved-only
 
   common-arm64: &common-arm64 # image: ghcr.io/opentensor/subtensor:v2.0.9-arm64
-    image: ghcr.io/opentensor/subtensor@sha256:53c7a539f47d20825c5f5bfbc06d9f8fd411f159fbb3805c99b6042a3c2c11aa # v3.1.0-arm64
+    image: ghcr.io/opentensor/subtensor:v3.1.0-arm64@sha256:3adc616fb62811007a59ef92942b0bd56fccc877a717c86012d4583566219a29
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.subtensor.yaml
+++ b/docker-compose.subtensor.yaml
@@ -39,22 +39,17 @@ services:
     volumes:
       - mainnet-lite-volume:/tmp/blockchain
     command:
-      - --base-path
-      - /tmp/blockchain
-      - --chain
-      - ./chainspecs/raw_spec_finney.json
-      - --rpc-external
-      - --rpc-cors
-      - all
-      - --no-mdns
-      - --in-peers
-      - "500"
-      - --out-peers
-      - "500"
-      - --bootnodes
-      - /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC
-      - --sync
-      - warp
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain raw_spec_finney.json \
+          --rpc-external --rpc-cors all \
+          --no-mdns \
+          --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
+          --sync warp
 
   testnet-lite-amd64:
     <<: *common-amd64
@@ -62,25 +57,19 @@ services:
     volumes:
       - testnet-lite-volume:/tmp/blockchain
     command:
-      - --base-path
-      - /tmp/blockchain
-      - --chain
-      - ./chainspecs/raw_spec_testfinney.json
-      - --rpc-external
-      - --rpc-cors
-      - all
-      - --no-mdns
-      - --in-peers
-      - "500"
-      - --out-peers
-      - "500"
-      - --bootnodes
-      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
-      - --sync
-      - warp
-      - --reserved-nodes
-      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
-      - --reserved-only
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain raw_spec_testfinney.json \
+          --rpc-external --rpc-cors all \
+          --no-mdns \
+          --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
+          --sync warp
+          --reserved-nodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
+          --reserved-only
 
   common-arm64: &common-arm64 # image: ghcr.io/opentensor/subtensor:v2.0.9-arm64
     image: ghcr.io/opentensor/subtensor:v3.1.0-arm64@sha256:3adc616fb62811007a59ef92942b0bd56fccc877a717c86012d4583566219a29
@@ -114,22 +103,17 @@ services:
     volumes:
       - mainnet-lite-volume:/tmp/blockchain
     command:
-      - --base-path
-      - /tmp/blockchain
-      - --chain
-      - ./chainspecs/raw_spec_finney.json
-      - --rpc-external
-      - --rpc-cors
-      - all
-      - --no-mdns
-      - --in-peers
-      - "500"
-      - --out-peers
-      - "500"
-      - --bootnodes
-      - /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC
-      - --sync
-      - warp
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain ./chainspecs/raw_spec_finney.json \
+          --rpc-external --rpc-cors all \
+          --no-mdns \
+          --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
+          --sync warp
 
   testnet-lite-arm64:
     <<: *common-arm64
@@ -137,22 +121,16 @@ services:
     volumes:
       - testnet-lite-volume:/tmp/blockchain
     command:
-      - --base-path
-      - /tmp/blockchain
-      - --chain
-      - ./chainspecs/raw_spec_testfinney.json
-      - --rpc-external
-      - --rpc-cors
-      - all
-      - --no-mdns
-      - --in-peers
-      - "500"
-      - --out-peers
-      - "500"
-      - --bootnodes
-      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
-      - --sync
-      - warp
-      - --reserved-nodes
-      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
-      - --reserved-only
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain raw_spec_testfinney.json \
+          --rpc-external --rpc-cors all \
+          --no-mdns \
+          --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
+          --sync warp
+          --reserved-nodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
+          --reserved-only

--- a/docker-compose.subtensor.yaml
+++ b/docker-compose.subtensor.yaml
@@ -8,7 +8,7 @@ networks:
 
 services:
   common-amd64: &common-amd64 # image: ghcr.io/opentensor/subtensor:v2.0.9-amd64
-    image: ghcr.io/opentensor/subtensor@sha256:e0d22ae345f8c8a241c69aecc4fffd364fd57665e1baf2e0135e8fd57501e2fc #v3.1.0-amd64
+    image: ghcr.io/opentensor/subtensor@sha256:83583997be9137c7e13fffce98752fa9a326a4bfabfd933544c14f0b693bc40b #v3.1.0-amd64
     build:
       context: .
       dockerfile: Dockerfile
@@ -72,7 +72,7 @@ services:
           --reserved-only
 
   common-arm64: &common-arm64 # image: ghcr.io/opentensor/subtensor:v2.0.9-arm64
-    image: ghcr.io/opentensor/subtensor@sha256:53c7a539f47d20825c5f5bfbc06d9f8fd411f159fbb3805c99b6042a3c2c11aa
+    image: ghcr.io/opentensor/subtensor@sha256:53c7a539f47d20825c5f5bfbc06d9f8fd411f159fbb3805c99b6042a3c2c11aa # v3.1.0-arm64
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.subtensor.yaml
+++ b/docker-compose.subtensor.yaml
@@ -39,17 +39,22 @@ services:
     volumes:
       - mainnet-lite-volume:/tmp/blockchain
     command:
-      - /bin/bash
-      - -c
-      - |
-        node-subtensor \
-          --base-path /tmp/blockchain \
-          --chain raw_spec_finney.json \
-          --rpc-external --rpc-cors all \
-          --no-mdns \
-          --in-peers 500 --out-peers 500 \
-          --bootnodes /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
-          --sync warp
+      - --base-path
+      - /tmp/blockchain
+      - --chain
+      - ./chainspecs/raw_spec_finney.json
+      - --rpc-external
+      - --rpc-cors
+      - all
+      - --no-mdns
+      - --in-peers
+      - "500"
+      - --out-peers
+      - "500"
+      - --bootnodes
+      - /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC
+      - --sync
+      - warp
 
   testnet-lite-amd64:
     <<: *common-amd64
@@ -57,19 +62,25 @@ services:
     volumes:
       - testnet-lite-volume:/tmp/blockchain
     command:
-      - /bin/bash
-      - -c
-      - |
-        node-subtensor \
-          --base-path /tmp/blockchain \
-          --chain raw_spec_testfinney.json \
-          --rpc-external --rpc-cors all \
-          --no-mdns \
-          --in-peers 500 --out-peers 500 \
-          --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
-          --sync warp
-          --reserved-nodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
-          --reserved-only
+      - --base-path
+      - /tmp/blockchain
+      - --chain
+      - ./chainspecs/raw_spec_testfinney.json
+      - --rpc-external
+      - --rpc-cors
+      - all
+      - --no-mdns
+      - --in-peers
+      - "500"
+      - --out-peers
+      - "500"
+      - --bootnodes
+      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
+      - --sync
+      - warp
+      - --reserved-nodes
+      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
+      - --reserved-only
 
   common-arm64: &common-arm64 # image: ghcr.io/opentensor/subtensor:v2.0.9-arm64
     image: ghcr.io/opentensor/subtensor:v3.1.0-arm64@sha256:3adc616fb62811007a59ef92942b0bd56fccc877a717c86012d4583566219a29
@@ -103,17 +114,22 @@ services:
     volumes:
       - mainnet-lite-volume:/tmp/blockchain
     command:
-      - /bin/bash
-      - -c
-      - |
-        node-subtensor \
-          --base-path /tmp/blockchain \
-          --chain raw_spec_finney.json \
-          --rpc-external --rpc-cors all \
-          --no-mdns \
-          --in-peers 500 --out-peers 500 \
-          --bootnodes /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
-          --sync warp
+      - --base-path
+      - /tmp/blockchain
+      - --chain
+      - ./chainspecs/raw_spec_finney.json
+      - --rpc-external
+      - --rpc-cors
+      - all
+      - --no-mdns
+      - --in-peers
+      - "500"
+      - --out-peers
+      - "500"
+      - --bootnodes
+      - /dns/bootnode.finney.chain.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC
+      - --sync
+      - warp
 
   testnet-lite-arm64:
     <<: *common-arm64
@@ -121,16 +137,22 @@ services:
     volumes:
       - testnet-lite-volume:/tmp/blockchain
     command:
-      - /bin/bash
-      - -c
-      - |
-        node-subtensor \
-          --base-path /tmp/blockchain \
-          --chain raw_spec_testfinney.json \
-          --rpc-external --rpc-cors all \
-          --no-mdns \
-          --in-peers 500 --out-peers 500 \
-          --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
-          --sync warp
-          --reserved-nodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
-          --reserved-only
+      - --base-path
+      - /tmp/blockchain
+      - --chain
+      - ./chainspecs/raw_spec_testfinney.json
+      - --rpc-external
+      - --rpc-cors
+      - all
+      - --no-mdns
+      - --in-peers
+      - "500"
+      - --out-peers
+      - "500"
+      - --bootnodes
+      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
+      - --sync
+      - warp
+      - --reserved-nodes
+      - /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
+      - --reserved-only

--- a/docker-compose.subtensor.yaml
+++ b/docker-compose.subtensor.yaml
@@ -7,9 +7,8 @@ networks:
     name: subtensor
 
 services:
-  common-amd64: &common-amd64
-    # image: ghcr.io/opentensor/subtensor:v2.0.9-amd64
-    image: ghcr.io/opentensor/subtensor@sha256:e0d22ae345f8c8a241c69aecc4fffd364fd57665e1baf2e0135e8fd57501e2fc
+  common-amd64: &common-amd64 # image: ghcr.io/opentensor/subtensor:v2.0.9-amd64
+    image: ghcr.io/opentensor/subtensor@sha256:e0d22ae345f8c8a241c69aecc4fffd364fd57665e1baf2e0135e8fd57501e2fc #v3.1.0-amd64
     build:
       context: .
       dockerfile: Dockerfile
@@ -72,9 +71,8 @@ services:
           --reserved-nodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr \
           --reserved-only
 
-  common-arm64: &common-arm64
-    # image: ghcr.io/opentensor/subtensor:v2.0.9-arm64
-    image: ghcr.io/opentensor/subtensor@sha256:f0f0be6dd2ba7d454ccf907acb948a46376ad8d57910c4043835d45772cd23be
+  common-arm64: &common-arm64 # image: ghcr.io/opentensor/subtensor:v2.0.9-arm64
+    image: ghcr.io/opentensor/subtensor@sha256:53c7a539f47d20825c5f5bfbc06d9f8fd411f159fbb3805c99b6042a3c2c11aa
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
- tagged arm64 to this digest: `sha256:53c7a539f47d20825c5f5bfbc06d9f8fd411f159fbb3805c99b6042a3c2c11aa`
- tagged amd64 to this digest: `sha256:83583997be9137c7e13fffce98752fa9a326a4bfabfd933544c14f0b693bc40b`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated container image versions for improved compatibility and performance in the docker-compose configuration.
	- Enhanced service configuration for more precise chain specification file referencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->